### PR TITLE
Fix libtoolize conflict caused by crlf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have LF line endings on checkout.
+*.sh text eol=lf
+*.ac text eol=lf
+*.am text eol=lf


### PR DESCRIPTION
The error was "AC_CONFIG_MACRO_DIRS([m4]) conflicts with
ACLOCAL_AMFLAGS=-I m4" and was solved by running dos2unix on it.

The .gitattributes file should prevent this issue in the future.